### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -55,7 +55,7 @@ jobs:
       #
       # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
       # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+      url: https://pypi.org/project/pre_commit_html/${{ github.event.release.name }}
 
     steps:
       - name: Retrieve release distributions


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/python-publish.yml` file. The change updates the URL for the PyPI project to reflect the correct project name.

* [`.github/workflows/python-publish.yml`](diffhunk://#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377L58-R58): Updated the URL to use `pre_commit_html` in the PyPI project URL.