### PR TITLE
Add Python debugging configuration and enhance pre_commit_html module

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Module",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pre_commit_html"
+        }
+    ]
+}

--- a/pre_commit_html/__init__.py
+++ b/pre_commit_html/__init__.py
@@ -56,24 +56,25 @@ class PreCommitParser:
             if "\\" in line and ":" in line and len(code_part) == 0:
                 h3_file = line.replace("\\", "/")
 
-                path_code_file = h3_file.split(":")[0]
-                line_code = h3_file.split(":")[1]
-                column_code = h3_file.split(":")[2]
-                message = h3_file.split(":")[3]
+                if len(h3_file.split(":")) == 4:
+                    path_code_file = h3_file.split(":")[0]
+                    line_code = h3_file.split(":")[1]
+                    column_code = h3_file.split(":")[2]
+                    message = h3_file.split(":")[3]
 
-                ruff_ref = message.split(" ")[1]
+                    ruff_ref = message.split(" ")[1]
 
-                code_error.append(
-                    "".join(
-                        (
-                            f'<h3>File: <a href="./{path_code_file}:{line_code}:',
-                            f'{column_code}">{path_code_file}:{line_code}:{column_code}</a></h3>',
+                    code_error.append(
+                        "".join(
+                            (
+                                f'<h3>File: <a href="./{path_code_file}:{line_code}:',
+                                f'{column_code}">{path_code_file}:{line_code}:{column_code}</a></h3>',
+                            )
                         )
                     )
-                )
-                code_error.append(
-                    f'<p>Error: <a href="https://docs.astral.sh/ruff/rules/#{ruff_ref}">{ruff_ref}</a>{message}</p>'
-                )
+                    code_error.append(
+                        f'<p>Error: <a href="https://docs.astral.sh/ruff/rules/#{ruff_ref}">{ruff_ref}</a>{message}</p>'
+                    )
 
             elif "\\" in line and ":" in line and len(code_part) > 0:
                 h3_file = line.replace("\\", "/")

--- a/pre_commit_html/__main__.py
+++ b/pre_commit_html/__main__.py
@@ -9,3 +9,7 @@ def main() -> None:
     This function calls the pre_commit_html method from the PreCommitParser class.
     """
     PreCommitParser.pre_commit_html()
+
+
+if __name__ == "__main__":
+    SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ license = "MIT"
 requires-python = ">=3.13"
 dependencies = ["pre-commit (>=4.1.0,<5.0.0)", "jinja2 (>=3.1.5,<4.0.0)"]
 
+[tool.poetry.scripts]
+pre_commit_html = "pre_commit_html:__main__"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
This pull request includes several changes to enhance the debugging configuration, improve the `pre_commit_html` function, and ensure the script can be executed directly. The most important changes are listed below:

### Debugging Configuration:

* Added a new debugging configuration for the Python module `pre_commit_html` in the `.vscode/launch.json` file. This allows developers to use the Python Debugger with the specified module.

### Function Improvements:

* Modified the `pre_commit_html` function in `pre_commit_html/__init__.py` to handle cases where the split result of `h3_file` has exactly four parts. This ensures that the path, line, and column code are correctly assigned.

### Script Execution:

* Updated the `main` function in `pre_commit_html/__main__.py` to call `SystemExit(main())` when the script is executed as the main module. This allows the script to be run directly from the command line.

### Project Configuration:

* Added an entry for `pre_commit_html` in the `[tool.poetry.scripts]` section of `pyproject.toml`. This registers the script with Poetry, making it easier to execute the script using the `poetry run` command.