### PR TITLE
Enhance pre-commit-html functionality and documentation

### DIFF
--- a/.github/.copilot-code-edit-instructions.md
+++ b/.github/.copilot-code-edit-instructions.md
@@ -1,0 +1,2 @@
+For docstrings, make sure all Python code follows PEP 8 and PEP 257 standards. Automatically generate docstrings for all functions, methods, and classes using Google's docstring style. Additionally, it is mandatory to include a module-level docstring at the beginning of each file. If an existing document string doesn't conform to Google's style, rewrite it to match the correct format. Docstrings for modules can never start with "This" and the docstring summary must always end with a period.
+The last session requires a blank line after it.

--- a/.github/.copilot-commit-message-instructions.md
+++ b/.github/.copilot-commit-message-instructions.md
@@ -1,9 +1,9 @@
-Use conventional commit message format.
+Use the conventional commit message format.
 
-Includes task id, type of change, and a brief description of the changes.
+Includes task ID, change type, and a brief description of the changes.
 
-The task ID can be found in previous commits, at the beginning of your message (something like "[RHP-103]" or similar). Always include this at the beginning of your message.
+The task ID can be found in previous commits, at the beginning of its message (something like "[RHP-103]" or similar). Always include this at the beginning of your message. Always use the most recent Task ID
 
-Separando por linhas, procure sempre detalhar o que foi feito
+Separating by lines, always try to detail what was done
 
-Separating by lines, if there are multiple types of change (e.g. 3 files were refacted, 2 were just documentation), always try to detail what was done in each file, grouping them by type of change (e.g.: `'Chore' \n index.html: added js module`), informing the name of the file in the first line along with the type of change (chore, refact, etc.)
+Separating by lines, if there are types of changes (ex: 3 files were refactored, 2 were just documents), always try to detail what was done in each file, grouping several by type of change (ex: `'Chore' \n index.html: added js module`), informing the name of the file in the first line along with the type of change (chore, refact, etc.)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  # 1. Faz linting e correções adicionais no final
+  - repo: "https://github.com/astral-sh/ruff-pre-commit"
+    rev: "v0.9.3"
+    hooks:
+      - id: "ruff"
+        args: [--fix]
+
+      - id: ruff-format
+
+  # bandit linter
+  - repo: "https://github.com/PyCQA/bandit"
+    rev: "1.8.2"
+    hooks:
+      - id: "bandit"
+        name: "bandit"
+        description: "Bandit is a tool for finding common security issues in Python code"
+        entry: "bandit"
+        language: "python"
+        language_version: "python3"
+        types: ["python"]
+        require_serial: true
+        args:
+          - "-c"
+          - "pyproject.toml"
+          - "-o"
+          - "results/bandit.html"
+          - "-f"
+          - "html"
+        additional_dependencies: ["bandit[toml]"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project is designed to run pre-commit hooks and format the results into an 
 
 ## How It Works
 
-1. **Run Pre-Commit Hooks**: The `PreCommitParser` class runs the pre-commit hooks using the `pre-commit run --all-files` command.
+1. **Run Pre-Commit Hooks**: The `PreCommitToHTML` class runs the pre-commit hooks using the `pre-commit run --all-files` command.
 2. **Parse Output**: The output from the pre-commit hooks is parsed to extract relevant information such as file paths, line numbers, column numbers, and error messages.
 3. **Generate HTML**: The parsed information is then formatted into an HTML file using Jinja2 templates. The HTML file includes links to the relevant lines in the source code and references to the documentation for the errors.
 
@@ -43,7 +43,7 @@ This will generate an HTML file named `result_pre_commit.html` in the project di
 ## Project Structure
 
 - `pre_commit_html/__main__.py`: Contains the main function to run the pre-commit formatter.
-- `pre_commit_html/__init__.py`: Contains the `PreCommitParser` class which handles running the pre-commit hooks and formatting the output.
+- `pre_commit_html/__init__.py`: Contains the `PreCommitToHTML` class which handles running the pre-commit hooks and formatting the output.
 - `site/templates/`: Contains the Jinja2 templates used to generate the HTML file.
 
 ## Templates

--- a/docs/README-pt.md
+++ b/docs/README-pt.md
@@ -16,7 +16,7 @@ Este projeto é projetado para executar hooks de pré-commit e formatar os resul
 
 ## Como Funciona
 
-1. **Executar Hooks de Pré-Commit**: A classe `PreCommitParser` executa os hooks de pré-commit usando o comando `pre-commit run --all-files`.
+1. **Executar Hooks de Pré-Commit**: A classe `PreCommitToHTML` executa os hooks de pré-commit usando o comando `pre-commit run --all-files`.
 2. **Analisar Saída**: A saída dos hooks de pré-commit é analisada para extrair informações relevantes, como caminhos de arquivos, números de linha, números de coluna e mensagens de erro.
 3. **Gerar HTML**: As informações analisadas são então formatadas em um arquivo HTML usando templates Jinja2. O arquivo HTML inclui links para as linhas relevantes no código-fonte e referências à documentação dos erros.
 
@@ -41,7 +41,7 @@ Isso gerará um arquivo HTML chamado `result_pre_commit.html` no diretório do p
 ## Estrutura do Projeto
 
 - `pre_commit_html/__main__.py`: Contém a função principal para executar o formatter de pré-commit.
-- `pre_commit_html/__init__.py`: Contém a classe `PreCommitParser`, que lida com a execução dos hooks de pré-commit e a formatação da saída.
+- `pre_commit_html/__init__.py`: Contém a classe `PreCommitToHTML`, que lida com a execução dos hooks de pré-commit e a formatação da saída.
 - `site/templates/`: Contém os templates Jinja2 usados para gerar o arquivo HTML.
 
 ## Templates

--- a/pre_commit_html/__main__.py
+++ b/pre_commit_html/__main__.py
@@ -1,15 +1,6 @@
-"""This module contains the main function to run the pre-commit formatter."""
+"""Module containing the main function to run the pre-commit formatter."""
 
-from . import PreCommitParser
-
-
-def main() -> None:
-    """Main function to run the pre-commit formatter.
-
-    This function calls the pre_commit_html method from the PreCommitParser class.
-    """
-    PreCommitParser.pre_commit_html()
-
+from pre_commit_html.main import main
 
 if __name__ == "__main__":
     SystemExit(main())

--- a/pre_commit_html/main.py
+++ b/pre_commit_html/main.py
@@ -1,0 +1,18 @@
+"""Main module for the pre-commit-html package."""
+
+import argparse
+import sys
+from typing import Sequence
+
+from pre_commit_html import PreCommitToHTML
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the pre-commit formatter."""
+    argv = argv if argv is not None else sys.argv[1:]
+    parser = argparse.ArgumentParser(prog="pre-commit-html")
+
+    parser.add_argument("-i", "--IDE", type=str, help="The IDE to open the file in.", default="VS Code")
+
+    args = parser.parse_args(argv)
+    PreCommitToHTML(ide=args.IDE)

--- a/pre_commit_html/utils.py
+++ b/pre_commit_html/utils.py
@@ -1,0 +1,52 @@
+"""Utility functions for generating file editor links.
+
+This module provides functionality for constructing URLs that open files in various
+editors. It supports multiple editor URL schemes.
+"""
+
+import pathlib
+from urllib.parse import quote
+
+
+def generate_editor_links(path: str, line: int = None, column: int = None) -> dict[str, str]:
+    """Generate multiple editor links for opening files.
+
+    Args:
+        path (str): The file path.
+        line (int, optional): The line number in the file.
+        column (int, optional): The column number in the file.
+
+    Returns:
+        dict[str, str]: A dictionary containing editor-specific URL schemes.
+
+    """
+    file_path = pathlib.Path(path).resolve()
+    file_uri = file_path.as_uri()  # file:// format
+    escaped_path = quote(str(file_path))  # For editors like VS Code, JetBrains, Sublime, Atom, etc.
+
+    # Formatted line and column strings
+    line_str = f":{line}" if line else ""
+    column_str = f":{column}" if column else ""
+
+    # Editor-specific URL formats
+    links = {
+        "file://": f"{file_uri}{f'#L{line}' if line else ''}{f'C{column}' if column else ''}",
+        "VS Code": f"vscode://file/{escaped_path}{line_str}{column_str}",
+        "Nova (macOS)": (
+            f"nova://open?path={escaped_path}{f'&line={line}' if line else ''}{f'&column={column}' if column else ''}"
+        ),
+        "Sublime Text": (
+            f"subl://open?url=file://{escaped_path}"
+            f"{f'&line={line}' if line else ''}"
+            f"{f'&column={column}' if column else ''}"
+        ),
+        "Atom": (
+            f"atom://core/open/file?filename={escaped_path}"
+            f"{f'&line={line}' if line else ''}"
+            f"{f'&column={column}' if column else ''}"
+        ),
+        "BBEdit (macOS)": f"bbedit://open?path={escaped_path}{f'&line={line}' if line else ''}",
+        "Vim/Nvim": f"vim://open?url=file://{escaped_path}{f'&line={line}' if line else ''}",
+    }
+
+    return links

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pre_commit_html"
-version = "0.1.2"
+version = "0.1.3"
 description = "Format results from pre-commit cmd to HTML file"
 authors = [{ name = "Robotz213", email = "nicholas@robotz.dev" }]
 readme = "README.md"
@@ -9,7 +9,7 @@ requires-python = ">=3.13"
 dependencies = ["pre-commit (>=4.1.0,<5.0.0)", "jinja2 (>=3.1.5,<4.0.0)"]
 
 [tool.poetry.scripts]
-pre_commit_html = "pre_commit_html:__main__"
+pre-commit-html = "pre_commit_html:__main__"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.9.5"
+
+[tool.bandit]
+exclude_dirs = ["tests", ".venv"]
+skips = ["B603", "B404", "B607", "B701"]

--- a/results/bandit.html
+++ b/results/bandit.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+
+    <meta charset="UTF-8">
+
+    <title>
+      Bandit Report
+    </title>
+
+    <style>
+      html * {
+        font-family: "Arial", sans-serif;
+      }
+
+      pre {
+        font-family: "Monaco", monospace;
+      }
+
+      .bordered-box {
+        border: 1px solid black;
+        padding-top: .5em;
+        padding-bottom: .5em;
+        padding-left: 1em;
+      }
+
+      .metrics-box {
+        font-size: 1.1em;
+        line-height: 130%;
+      }
+
+      .metrics-title {
+        font-size: 1.5em;
+        font-weight: 500;
+        margin-bottom: .25em;
+      }
+
+      .issue-description {
+        font-size: 1.3em;
+        font-weight: 500;
+      }
+
+      .candidate-issues {
+        margin-left: 2em;
+        border-left: solid 1px LightGray;
+        padding-left: 5%;
+        margin-top: .2em;
+        margin-bottom: .2em;
+      }
+
+      .issue-block {
+        border: 1px solid LightGray;
+        padding-left: .5em;
+        padding-top: .5em;
+        padding-bottom: .5em;
+        margin-bottom: .5em;
+      }
+
+      .issue-sev-high {
+        background-color: Pink;
+      }
+
+      .issue-sev-medium {
+        background-color: NavajoWhite;
+      }
+
+      .issue-sev-low {
+        background-color: LightCyan;
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <div id="metrics">
+      <div class="metrics-box bordered-box">
+        <div class="metrics-title">
+          Metrics:<br>
+        </div>
+        Total lines of code: <span id="loc">161</span><br>
+        Total lines skipped (#nosec): <span id="nosec">0</span>
+      </div>
+    </div>
+
+
+
+
+    <br>
+    <div id="results">
+
+    </div>
+
+  </body>
+
+</html>

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,133 @@
+preview = true
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "tests",
+    "Lib",
+]
+
+extend-exclude = ["hooks"]
+extend-include = ["*.ipynb"]
+line-length = 120
+indent-width = 4
+
+[lint]
+select = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W"]
+
+extend-select = [
+    "ANN",
+    "ASYNC",
+    "COM",
+    "EXE",
+    "PYI",
+    "PT",
+    "RSE",
+    "ISC",
+    "ICN",
+    "LOG",
+    "PIE",
+    "SLF",
+    "SLOT",
+    "PGH",
+    "INT",
+    "TD",
+    "FIX",
+    "NPY",
+    # "INP",
+    # "UP",
+    # "RET",
+    # "BLE",
+    # "FBT",
+    # "CPY",
+    # "DTZ",
+    # "EM",
+    # "FA",
+    # "SIM",
+    # "TID",
+    # "TC",
+    # "ARG",
+    # "PTH",
+    # "ERA",
+    # "PD",
+    # "PL",
+    # "TRY",
+    # "FLY",
+    # "AIR",
+    # "PERF",
+    # "FURB",
+    # "DOC",
+    # "RUF",
+]
+
+ignore = [
+    "COM812",
+    "D203",
+    "D211",
+    "D212",
+    "D213",
+    "S603",
+    "S607",
+    "S404",
+    "C901",
+    "ANN401",
+]
+
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = true
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = pre_commit_html
+version = 0.1.3
+description = Format results from pre-commit cmd to HTML file
+author = Robotz213
+author_email = nicholas@robotz.dev
+license = MIT
+long_description = file: README.md
+
+[options]
+python_requires = >=3.13
+install_requires =
+    pre-commit>=4.1.0,<5.0.0
+    jinja2>=3.1.5,<4.0.0
+
+[options.entry_points]
+console_scripts =
+    pre-commit-html = pre_commit_html:__main__


### PR DESCRIPTION
This pull request includes several updates to improve the pre-commit HTML formatter, enhance documentation, and add new configuration files. The most important changes include renaming the main class, adding new utilities, and updating documentation and configuration files.

### Codebase Improvements:
* `pre_commit_html/__init__.py`: Renamed the `PreCommitParser` class to `PreCommitToHTML` and added the `generate_editor_links` utility function to create editor-specific links. (F486e4ffR1)
* [`pre_commit_html/main.py`](diffhunk://#diff-3c67ce31cdbb0a202e943d10b57e4e00473193d70d840be3097206d1aacee6d9R1-R18): Added a new main module to handle command-line arguments and initialize the `PreCommitToHTML` class.
* [`pre_commit_html/utils.py`](diffhunk://#diff-ae1e0dd260bd1b977b3bf423d80bf980bc79379d7111d40d539a9e2676a0ebb6R1-R52): Added a new utility module to generate file editor links for various editors.

### Documentation Updates:
* [`.github/.copilot-code-edit-instructions.md`](diffhunk://#diff-7b152bea63db5e3f7b5381ec794ce2907890b1e552c41fb93594ba660369ff71R1-R2): Updated docstring requirements to follow PEP 8 and PEP 257 standards and use Google's docstring style.
* `README.md` and `docs/README-pt.md`: Updated references from `PreCommitParser` to `PreCommitToHTML` in both English and Portuguese documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21) [[2]](diffhunk://#diff-4ed211ede0a4a6011f3007129da01b44e3c8525295dd279554bb196a12578aa4L19-R19)

### Configuration Updates:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R1-R30): Added new pre-commit hooks for `ruff` and `bandit` linters.
* `pyproject.toml` and `setup.cfg`: Updated project version to 0.1.3, added new dependencies, and configured entry points for the pre-commit HTML formatter. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R1-R18)
* [`ruff.toml`](diffhunk://#diff-26f436cb29eecc7bb4f9066747b43df8da81ac808955ce95c109f5d7aa778989R1-R133): Added configuration for the `ruff` linter, including exclusions, line length, and formatting rules.